### PR TITLE
Fix build with Clang/LLVM version 11

### DIFF
--- a/src/paml.h
+++ b/src/paml.h
@@ -372,9 +372,9 @@ void copySptree(void);
 void printSptree(void);
 
 
-enum {BASEseq=0, CODONseq, AAseq, CODON2AAseq, BINARYseq, BASE5seq} SeqTypes;
+enum SeqTypes {BASEseq=0, CODONseq, AAseq, CODON2AAseq, BINARYseq, BASE5seq};
 
-enum {PrBranch=1, PrNodeNum=2, PrLabel=4, PrNodeStr=8, PrAge=16, PrOmega=32} OutTreeOptions;
+enum OutTreeOptions {PrBranch=1, PrNodeNum=2, PrLabel=4, PrNodeStr=8, PrAge=16, PrOmega=32};
 
 
 /* use mean (0; default) for discrete gamma instead of median (1) */


### PR DESCRIPTION
Merging of tentative definitions by the linker gives multiple-definition errors
with Clang/LLVM version 11, which uses -fno-common by default.

These tentative definitions of anonymous enums are included multiple times in
the translation unit, resulting in the error above.  Since they are unused,
switch them to non-anonymous enums without any declaration or definition.

Submitted by: Kyle Evans (to the FreeBSD port)