### PR TITLE
Remove -Wmemset-elt-size from CFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 PRGS =  baseml codeml basemlg mcmctree pamp evolver yn00 chi2
 CC = cc # cc, gcc, cl
-CFLAGS = -O3 -Wall -Wno-unused-result -Wmemset-elt-size
+CFLAGS = -O3 -Wall -Wno-unused-result
 #CC = icc
 #CFLAGS = -fast -Wall
 


### PR DESCRIPTION
The warning is only applicable to gcc and is already enabled with -Wall.