### PR TITLE
Fix issues #76 and #75

### DIFF
--- a/examples/DatingSoftBound/mcmctree.ctl
+++ b/examples/DatingSoftBound/mcmctree.ctl
@@ -16,7 +16,7 @@
 
      cleandata = 0    * remove sites with ambiguity data (1:yes, 0:no)?
 
-       BDparas = 1 1 0.1  * birth, death, sampling
+       BDparas = 1 1 0.1 multiplicative  * birth, death, sampling, multiplicative/conditional
    kappa_gamma = 6 2      * gamma prior for kappa
    alpha_gamma = 1 1      * gamma prior for alpha
 

--- a/src/ds.c
+++ b/src/ds.c
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 
    if(argc>1) strcpy(infile, argv[1]);
    if(argc>2) strcpy(outfile,argv[2]);
-   fp = (FILE*)gfopen(outfile,"w");
+   fp = (FILE*)zopen(outfile,"w");
    puts("results go into out.txt");
    starttimer();
    DescriptiveStatistics(fp, infile, 100, 0, 1);

--- a/src/mcmctree.c
+++ b/src/mcmctree.c
@@ -1235,14 +1235,14 @@ int GetOptions(char *ctlf)
                case (20): com.ncatG = (int)t;      break;
                case (21): com.cleandata = (int)t;  break;
                case (22):
-                  ch = -1;
+                  ch = -1;  /* there may be either 3 or 4 parameters in the BDS model. */
                   sscanf(pline + 1, "%lf%lf%lf%lf%c", &data.BDS[0], &data.BDS[1], &data.BDS[2], &data.BDS[3], &ch);
                   if (ch == -1)
                      sscanf(pline + 1, "%lf%lf%lf %c", &data.BDS[0], &data.BDS[1], &data.BDS[2], &ch);
                   ch = toupper(ch);
                   if (ch == 'C')       data.BDS_flag = 0;
                   else if (ch == 'M')  data.BDS_flag = 1;
-                  else if (ch >= 'A' && ch <= 'Z') zerror("unrecognised flag for birth-death process prior");
+                  else                 zerror("Flag for birth-death process prior expected: C for conditional, M for multiplicative");
                   break;                 
                case (23):
                   sscanf(pline + 1, "%lf%lf", data.kappagamma, data.kappagamma + 1); break;

--- a/src/paml.h
+++ b/src/paml.h
@@ -389,6 +389,6 @@ enum PrintOptions { PrBranch = 1, PrNodeNum = 2, PrLabel = 4, PrNodeStr = 8, PrA
 
 #define PAML_RELEASE      0
 
-#define pamlVerStr "paml version 4.10.8, 15 May 2025"
+#define pamlVerStr "paml version 4.10.9, 7 May 2025"
 
 #endif

--- a/src/treesub.c
+++ b/src/treesub.c
@@ -7934,8 +7934,8 @@ int minB(FILE* fout, double* lnL, double x[], double xb[][2], double e0, double 
    com.ntime = ntime0;
    com.fix_blength = fix_blength0;
    *lnL = com.plfun(x, com.np); /* restore things, for e.g. AncestralSeqs */
-   if (fabs(*lnL - lnL0) > 1e-3)
-      printf("%.6f != %.6f lnL error.  Something is wrong in minB\n", *lnL, lnL0);
+   if (fabs(*lnL - lnL0) > 0.1)
+      printf("%.6f != %.6f lnL error.  Something may be wrong in minB\n", *lnL, lnL0);
    free(space_minbranches);
 
    return (status == -1 ? -1 : 0);


### PR DESCRIPTION
The following issues have been addressed:

* [Issue #75](https://github.com/abacus-gene/paml/issues/75): following [@mariodosreis](https://github.com/mariodosreis)'s suggestion 1, users must now choose either the conditional (add option `c` or `C` in variable `BDparas`) or the multiplicative (add option `m` or `M` in variable `BDparas`) construction. Please note that the old control files will not work anymore and shall trigger the following error message: `error: Flag for birth-death process prior expected: C for conditional, M for multiplicative`.
* [Issue #76](https://github.com/abacus-gene/paml/issues/76): following [@mariodosreis](https://github.com/mariodosreis)'s suggestion, the test has been relaxed. Instead of using `1e-3`, now `0.1` is used and a warning stating `may be wrong` (instead of error `is wrong`) will be printed, which may be ignored. In theory, the log-likelihood difference is more meaningful than the relative log-likelihood difference.
* `PAML` program `ds` would not compile due to an issue with opening files. [@xflouris](https://github.com/xflouris) has updated the code so that it uses `zopen` instead of `gfopen`, which fixed this issue.

These changes will be part of a new `PAML` release: `PAML` v4.10.9.