### PR TITLE
mcmctree: fix compile error

### DIFF
--- a/src/mcmctree.c
+++ b/src/mcmctree.c
@@ -42,7 +42,7 @@ extern double PjumpOptimum;
 
 int GetOptions(char *ctlf);
 int ReadTreeSeqs(FILE*fout);
-int ProcessNodeAnnotation();
+int ProcessNodeAnnotation(int* haslabel);
 int ReadBlengthGH(char infile[]);
 int GenerateBlengthGH(char infile[]);
 int GetMem(void);


### PR DESCRIPTION
mcmctree faces compile error

The function declaration should be changed.

Error report shows below

```
In file included from yn00.c:69:
treesub.c: In function ‘DistanceMatNG86’:
treesub.c:2385:20: warning: variable ‘SEdn’ set but not used [-Wunused-but-set-variable]
 2385 |    double SEds=-1, SEdn=-1, p;
      |                    ^~~~
treesub.c:2385:11: warning: variable ‘SEds’ set but not used [-Wunused-but-set-variable]
 2385 |    double SEds=-1, SEdn=-1, p;
      |           ^~~~
In file included from codeml.c:244:
treesub.c: In function ‘DistanceMatNG86’:
treesub.c:2385:20: warning: variable ‘SEdn’ set but not used [-Wunused-but-set-variable]
 2385 |    double SEds=-1, SEdn=-1, p;
      |                    ^~~~
treesub.c:2385:11: warning: variable ‘SEds’ set but not used [-Wunused-but-set-variable]
 2385 |    double SEds=-1, SEdn=-1, p;
      |           ^~~~
In file included from mcmctree.c:210:
treesub.c:8653:5: error: conflicting types for ‘ProcessNodeAnnotation’; have ‘int(int *)’
 8653 | int ProcessNodeAnnotation(int* haslabel)
      |     ^~~~~~~~~~~~~~~~~~~~~
mcmctree.c:45:5: note: previous declaration of ‘ProcessNodeAnnotation’ with type ‘int(void)’
   45 | int ProcessNodeAnnotation();
      |     ^~~~~~~~~~~~~~~~~~~~~
baseml.c: In function ‘main’:
baseml.c:407:7: warning: ‘memset’ used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
  407 |       memset(com.spname, 0, NS * sizeof(char));
      |       ^~~~~~
codeml.c: In function ‘main’:
codeml.c:582:7: warning: ‘memset’ used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
  582 |       memset(com.spname, 0, NS * sizeof(char));
      |       ^~~~~~
make: *** [Makefile:38: mcmctree.o] Error 1
make: *** Waiting for unfinished jobs....
```

my environment 

- OS: archlinux
- GCC
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.1.1 20250425 (GCC) 
```