### PR TITLE
codeml: optional CUDA backend for P(t) and ConditionalPNode

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,14 +4,28 @@ CFLAGS = -O3 -Wall -Wno-unused-variable -Wno-unused-result
 
 LIBS = -lm
 
+# Optional CUDA backend for codeml, off unless asked for:
+#   make codeml CUDA=1 GPU_ARCH=sm_86
+# Every other program, and codeml without CUDA=1, builds exactly as before.
+# -fmad=false is required rather than preferred: FMA contraction changes the
+# rounding of the multiply-accumulate and the results stop matching the C.
+ifdef CUDA
+NVCC ?= nvcc
+GPU_ARCH ?= sm_86
+CUDA_HOME ?= /usr/local/cuda
+CUDA_CFLAGS = -DENABLE_CUDA
+CUDA_OBJS = pmatcuda.o
+CUDA_LIBS = -L$(CUDA_HOME)/lib64 -lcudart_static -lpthread -ldl -lrt
+endif
+
 all : $(PRGS)
 
 baseml : baseml.o tools.o treesub.c treespace.c paml.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ baseml.o tools.o $(LIBS)
 basemlg: basemlg.o tools.o treesub.c treespace.c paml.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ basemlg.o tools.o $(LIBS)
-codeml: codeml.o tools.o treesub.c treespace.c paml.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ codeml.o tools.o $(LIBS)
+codeml: codeml.o tools.o $(CUDA_OBJS) treesub.c treespace.c paml.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ codeml.o tools.o $(CUDA_OBJS) $(CUDA_LIBS) $(LIBS)
 evolver: evolver.o tools.o treesub.c treespace.c paml.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ evolver.o tools.o $(LIBS)
 pamp: pamp.o tools.o treesub.c treespace.c paml.h
@@ -33,7 +47,10 @@ baseml.o : paml.h baseml.c treesub.c treespace.c
 basemlg.o : paml.h basemlg.c treesub.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -c basemlg.c
 codeml.o : paml.h codeml.c treesub.c treespace.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -c codeml.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CUDA_CFLAGS) $(LDFLAGS) -c codeml.c
+
+pmatcuda.o : pmatcuda.cu pmatcuda.h
+	$(NVCC) -O2 -arch=$(GPU_ARCH) -fmad=false -c pmatcuda.cu -o $@
 evolver.o : evolver.c treesub.c treespace.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -c evolver.c
 mcmctree.o : paml.h mcmctree.c treesub.c treespace.c

--- a/src/codeml.c
+++ b/src/codeml.c
@@ -15,11 +15,16 @@
 */
 
 #include "paml.h"
+#ifdef ENABLE_CUDA
+#include "pmatcuda.h"
+#endif
 
 #define NS            5000
 #define NBRANCH       (NS*2 - 2)
 #define NNODE         (NS*2 - 1)
-#define MAXNSONS      3
+/* StarDecomposition (runmode = 2) gives the root com.ns sons, so sons[]
+   must hold a star, not just a trifurcation. baseml already uses 64. */
+#define MAXNSONS      64
 #define NGENE         2000
 #define LSPNAME       96
 #define NCODE         64
@@ -289,7 +294,13 @@ int main(int argc, char *argv[])
    mergeSeqs(frst);  exit(0);
    Ina();
    */
-   SetSeed(-1, 0);
+   /* codeml seeds from /dev/urandom (or the clock) on every run, so starting
+      values, iteration counts and the last digits of the estimates all vary
+      between identical runs. PAML_SEED pins it so two builds can be compared. */
+   {
+      const char *sd = getenv("PAML_SEED");
+      SetSeed(sd ? atoi(sd) : -1, 0);
+   }
 
 #if (DSDN_MC || DSDN_MC_SITES)
    SimulateData2s61();
@@ -1376,9 +1387,15 @@ void DetailOutput(FILE *fout, double x[], double var[])
             else if (com.model == NSbranchB) om = x[k + i];
             else if (com.model == NSbranch2) om = nodes[tree.branches[i][1]].omega;
 
-            if (com.model == 0 || (com.model == FromCodon0  && com.aaDist))
+            if (com.model == 0 || (com.model == FromCodon0  && com.aaDist)) {
+               /* These are the models with no branch types, so a tree here
+                  carries no branch labels and ReadTreeN leaves label at -1.
+                  Scaling by it walks com.pomega backwards off x. */
+               int ib = (int)nodes[tree.branches[i][1]].label;
+               if (ib < 0) ib = 0;
                com.pomega = x + com.ntime + com.nrgene + !com.fix_kappa + com.npi
-               + (int)nodes[tree.branches[i][1]].label*com.nOmegaType;
+               + ib*com.nOmegaType;
+            }
 
             mr = 0;
             eigenQcodon(2, t, &S, &dS, &dN, NULL, NULL, NULL, &mr, com.pkappa, om, PMat); /* PMat destroyed! */
@@ -3226,6 +3243,7 @@ int SelectionCoefficients(FILE* fout, double kappa[], double ppi[], double omega
 }
 
 
+
 int eigenQcodon(int mode, double blength, double *S, double *dS, double *dN,
    double Root[], double U[], double V[], double *meanrate, double kappa[], double omega, double Q[])
 {
@@ -3523,10 +3541,482 @@ int Qcodon2aa(double Qc[], double pic[], double Qaa[], double piaa[])
 }
 
 
+#ifdef ENABLE_CUDA
+
+/* Batched P(t) and a device-resident ConditionalPNode.
+ *
+ * GetPMatBranch computes one 61x61 P(t) per branch and ConditionalPNode
+ * consumes it immediately, which is too little work to cover a kernel launch
+ * (0.2x at batch 1). Within one site class SetPSiteClass fixes U/V/Root, so
+ * every branch shares them and only t differs; computing all of them in one
+ * call reaches 7x at the natural batch of nbranch*ncatG.
+ *
+ * Returning P to the host then costs more than computing it: 29.8 kB per
+ * 227 kflop. The resident path avoids that by keeping P and conP on the device
+ * and running the traversal there, so only the root block comes back. It also
+ * moves the traversal's own GEMM, which is the larger cost on big trees:
+ * npatt*n*n per internal node against n*n*n per branch for P(t).
+ *
+ * Both paths need every branch to share U/V/Root, i.e. com.model == 0. The
+ * branch and branch-site models point U/V/Root at per-branch tables in
+ * GetPMatBranch, so they keep the C path.
+ */
+static double *pcache = NULL;      /* [nnode][n*n], indexed by node */
+static char *pcache_ok = NULL;     /* branch has a cached P(t) */
+static double *pcache_E = NULL;    /* host expm1 values */
+static int *pcache_slot = NULL;    /* batch slot -> node */
+static double *pcache_max = NULL;  /* NodeScale maxima, [NnodeScale][npatt] */
+static ConPWork *work = NULL;      /* all (parent, son) pairs, grouped */
+static size_t *work_dst = NULL;    /* interior node offsets */
+static size_t *work_sdst = NULL;   /* scaled node offsets */
+static int *work_slot = NULL;      /* scale slot per scaled node */
+static int pcache_n = 0, pcache_nnode = 0, pcache_npatt = 0, pcache_nscale = -1;
+
+/* Set while the device holds conP for the current traversal. */
+static int conp_resident = 0;
+/* Set while the device's conP is newer than com.conP. Any host path that
+   reads interior conP must sync first; see ConditionalPNode. */
+static int conp_dirty = 0;
+static int tips_uploaded = 0;
+static int *lvl = NULL;
+static unsigned long long topo_sig;
+
+void PMatCudaFreeCache(void)
+{
+   free(pcache_ok); free(pcache_slot);
+   PMatCudaHostFree(work); PMatCudaHostFree(work_dst);
+   PMatCudaHostFree(work_sdst); PMatCudaHostFree(work_slot);
+   PMatCudaHostFree(pcache);
+   PMatCudaHostFree(pcache_E);
+   PMatCudaHostFree(pcache_max);
+   pcache = pcache_E = pcache_max = NULL;
+   pcache_ok = NULL; pcache_slot = NULL;
+   work = NULL; work_dst = NULL; work_sdst = NULL; work_slot = NULL;
+   topo_sig = 0;
+   pcache_n = pcache_nnode = pcache_npatt = 0;
+   pcache_nscale = -1;
+   tips_uploaded = 0;
+}
+
+/* Non-zero when every node the traversal touches keeps its conP inside
+   com.conP, which is what lets the device mirror index by the host's own
+   offset. Interior nodes are assigned in InitConditionalPNode; a node below
+   com.ns with sons (a sampled ancestor) is not, so the resident path declines.
+   com.oldconP marks subtrees the caller intends to reuse, which would leave the
+   device holding values it never computed, so that declines too. */
+static int PMatCudaTreeOK(void)
+{
+   int i;
+   size_t nel = com.sconP / sizeof(double);
+
+   if (nel == 0) return 0;
+   for (i = 0; i < tree.nnode; i++) {
+      if (com.oldconP[i]) return 0;
+      if (nodes[i].nson > 0) {
+         if (i < com.ns) return 0;
+         if (nodes[i].conP < com.conP ||
+             (size_t)(nodes[i].conP - com.conP) + (size_t)com.ncode * com.npatt > nel)
+            return 0;
+      }
+   }
+   return 1;
+}
+
+/* Returns 1 if the batch was computed. `resident` leaves P on the device. */
+static int PMatCudaFillCache(double x[], int igene, int resident)
+{
+   int n = com.ncode, i, k, nb = 0;
+   double t;
+
+   if (getenv("PAML_NO_CUDA")) return 0;      /* runtime kill switch, for A/B */
+   if (!PMatCudaAvailable()) return 0;
+   /* Codon branch and branch-site models point U/V/Root at per-branch tables
+      in GetPMatBranch. Every such case is guarded there by CODONseq; the
+      amino acid models keep the global U/V/Root from eigenQaa. */
+   if (com.seqtype == CODONseq && com.model != 0) return 0;
+   if (com.seqtype == AAseq && com.model == Poisson) return 0;
+   if (com.clock >= 5 || com.clock) return 0; /* GetBranchRate path */
+   if (U == NULL || V == NULL || Root == NULL) return 0;
+
+   if (pcache_n != n || pcache_nnode != tree.nnode ||
+       pcache_npatt != com.npatt || pcache_nscale != com.NnodeScale) {
+      PMatCudaFreeCache();
+      /* pcache and pcache_E cross the bus, so they are page-locked; a pageable
+         copy stages through a driver bounce buffer, which is most of the
+         per-call cost at this batch size. */
+      pcache      = (double*)PMatCudaHostAlloc((size_t)tree.nnode * n * n * sizeof(double));
+      pcache_E    = (double*)PMatCudaHostAlloc((size_t)tree.nnode * n * sizeof(double));
+      pcache_max  = (double*)PMatCudaHostAlloc(
+                       (size_t)(com.NnodeScale ? com.NnodeScale : 1) * com.npatt * sizeof(double));
+      pcache_ok   = (char*)malloc((size_t)tree.nnode);
+      pcache_slot = (int*)malloc((size_t)tree.nnode * sizeof(int));
+      /* these cross the bus every traversal, so page-lock them: a staged copy
+         out of pageable memory costs ~15 us regardless of size */
+      work        = (ConPWork*)PMatCudaHostAlloc((size_t)tree.nnode * sizeof(ConPWork));
+      work_dst    = (size_t*)PMatCudaHostAlloc((size_t)tree.nnode * sizeof(size_t));
+      work_sdst   = (size_t*)PMatCudaHostAlloc((size_t)tree.nnode * sizeof(size_t));
+      work_slot   = (int*)PMatCudaHostAlloc((size_t)tree.nnode * sizeof(int));
+      if (!pcache || !pcache_E || !pcache_max || !pcache_ok || !pcache_slot ||
+          !work || !work_dst || !work_sdst || !work_slot) {
+         PMatCudaFreeCache();
+         return 0;
+      }
+      pcache_n = n; pcache_nnode = tree.nnode; pcache_npatt = com.npatt;
+      pcache_nscale = com.NnodeScale;
+   }
+   memset(pcache_ok, 0, (size_t)tree.nnode);
+
+   for (i = 0; i < tree.nnode; i++) {
+      if (i == tree.root) continue;
+      t = nodes[i].branch * _rateSite;
+      t *= com.rgene[igene];
+      if (t < -0.01) printf("\nt = %.5f in PMatUVRoot", t);
+      /* expm1 on the host: CUDA's differs in the last bit, and it is n calls
+         against n^3 for the product. t below PMatUVRoot's own cutoff takes
+         expm1 = 0, for which the kernel returns exactly the identity that
+         PMatUVRoot returns there. */
+      for (k = 0; k < n; k++)
+         pcache_E[(size_t)nb * n + k] = (t < 1e-100 ? 0.0 : expm1(t * Root[k]));
+      pcache_slot[nb] = i;
+      pcache_ok[i] = 1;
+      nb++;
+   }
+   if (nb == 0) return 0;
+
+   if (PMatUVRootBatchCudaSlot(pcache, pcache_E, U, V, pcache_slot, n, nb,
+                               0, 0, resident) != 0) {
+      memset(pcache_ok, 0, (size_t)tree.nnode);
+      return 0;
+   }
+   return 1;
+}
+
+/* Read by GetPMatBranch in treesub.c. */
+int pmat_cache_live = 0;
+double *pmat_cache_base = NULL;
+char *pmat_cache_flag = NULL;
+int pmat_cache_n = 0;
+
+/* Height of each node: 0 at a tip, 1 + max over sons otherwise. Nodes of equal
+   height have no dependence on each other, so they issue together.
+ *
+ * The grouping depends only on the topology, which is fixed while the
+ * optimizer runs, so it is built once and reused; each traversal only refills
+ * the conP offsets, which move when fx_r shifts the per-site-class pointers. */
+static int lvl_max = 0;
+static int *grp_start = NULL, *grp_count = NULL, *grp_lvl = NULL, n_grp = 0;
+static int *sgrp_start = NULL, *sgrp_count = NULL, *sgrp_lvl = NULL, n_sgrp = 0;
+static int *fold_par = NULL, *fold_son = NULL, n_fold = 0;
+static int *scale_node = NULL, *scale_k = NULL, n_scale = 0;
+
+/* The grouping depends on the topology, and codeml changes it under us:
+   a .trees file may hold several trees, and ReRootTree rewrites father and
+   sons in place. Both keep tree.nnode, so the node count cannot be the key.
+   FNV-1a over the structure is O(nnode) per traversal and catches any of
+   it. Bit 0 is reserved so a valid signature is never 0. */
+static unsigned long long PMatCudaTopoSig(void)
+{
+   unsigned long long h = 1469598103934665603ULL;
+   int i, j;
+
+#define MIX(v) do { h ^= (unsigned long long)(int)(v); \
+                    h *= 1099511628211ULL; } while (0)
+   MIX(tree.nnode); MIX(tree.root); MIX(com.ns); MIX(com.NnodeScale);
+   for (i = 0; i < tree.nnode; i++) {
+      MIX(nodes[i].nson);
+      MIX(com.NnodeScale ? com.nodeScale[i] : 0);
+      for (j = 0; j < nodes[i].nson; j++) MIX(nodes[i].sons[j]);
+   }
+#undef MIX
+   return h | 1;
+}
+
+static int SetNodeLevel(int inode)
+{
+   int i, h = 0, sh;
+   for (i = 0; i < nodes[inode].nson; i++) {
+      sh = SetNodeLevel(nodes[inode].sons[i]);
+      if (sh + 1 > h) h = sh + 1;
+   }
+   lvl[inode] = h;
+   if (h > lvl_max) lvl_max = h;
+   return h;
+}
+
+/* Groups the traversal's work by height and son slot. Within a group every
+   parent is distinct, so the folds cannot race; the groups run in order, which
+   is ConditionalPNode's son order. */
+static int PMatCudaBuildTopology(void)
+{
+   int i, L, sn, k, j, nw, cap = tree.nnode * 4;
+   unsigned long long sig = PMatCudaTopoSig();
+
+   if (topo_sig == sig) return 0;
+
+   free(lvl); free(grp_start); free(grp_count); free(grp_lvl);
+   free(sgrp_start); free(sgrp_count); free(sgrp_lvl);
+   free(fold_par); free(fold_son); free(scale_node); free(scale_k);
+   lvl = (int*)malloc((size_t)tree.nnode * sizeof(int));
+   grp_start = (int*)malloc((size_t)cap * sizeof(int));
+   grp_count = (int*)malloc((size_t)cap * sizeof(int));
+   grp_lvl = (int*)malloc((size_t)cap * sizeof(int));
+   sgrp_start = (int*)malloc((size_t)cap * sizeof(int));
+   sgrp_count = (int*)malloc((size_t)cap * sizeof(int));
+   sgrp_lvl = (int*)malloc((size_t)cap * sizeof(int));
+   fold_par = (int*)malloc((size_t)tree.nnode * sizeof(int));
+   fold_son = (int*)malloc((size_t)tree.nnode * sizeof(int));
+   scale_node = (int*)malloc((size_t)tree.nnode * sizeof(int));
+   scale_k = (int*)malloc((size_t)tree.nnode * sizeof(int));
+   if (!lvl || !grp_start || !grp_count || !grp_lvl || !sgrp_start ||
+       !sgrp_count || !sgrp_lvl || !fold_par || !fold_son || !scale_node ||
+       !scale_k) {
+      topo_sig = 0;
+      return -1;
+   }
+
+   lvl_max = 0;
+   SetNodeLevel(tree.root);
+
+   n_fold = 0; n_grp = 0; n_scale = 0; n_sgrp = 0;
+   for (L = 1; L <= lvl_max; L++) {
+      for (sn = 0; ; sn++) {
+         nw = 0;
+         for (i = 0; i < tree.nnode; i++) {
+            if (nodes[i].nson <= sn || lvl[i] != L) continue;
+            fold_par[n_fold + nw] = i;
+            fold_son[n_fold + nw] = nodes[i].sons[sn];
+            nw++;
+         }
+         if (nw == 0) break;
+         grp_start[n_grp] = n_fold; grp_count[n_grp] = nw;
+         grp_lvl[n_grp] = L; n_grp++;
+         n_fold += nw;
+      }
+      if (!com.NnodeScale) continue;
+      nw = 0;
+      for (i = 0; i < tree.nnode; i++) {
+         if (lvl[i] != L || !com.nodeScale[i]) continue;
+         for (j = 0, k = 0; j < tree.nnode; j++)   /* k-th node for scaling */
+            if (j == i) break;
+            else if (com.nodeScale[j]) k++;
+         scale_node[n_scale + nw] = i;
+         scale_k[n_scale + nw] = k;
+         nw++;
+      }
+      if (nw == 0) continue;
+      sgrp_start[n_sgrp] = n_scale; sgrp_count[n_sgrp] = nw;
+      sgrp_lvl[n_sgrp] = L; n_sgrp++;
+      n_scale += nw;
+   }
+   topo_sig = sig;
+   return 0;
+}
+
+/* Issues the same work ConditionalPNode does, a height at a time.
+ *
+ * ConditionalPNode walks post-order and folds each son into its parent the
+ * moment it is ready. The order that matters for the result is only: a node's
+ * sons before the node, and a node's sons in index order, since each fold is a
+ * read-modify-write of the parent. Both hold here. Setting every parent to 1 up
+ * front is safe for the same reason: nothing reads a block before its own folds
+ * begin.
+ *
+ * Every accumulation keeps PAML's order, so the result is bit-identical; see
+ * the kernels in pmatcuda.cu. */
+static int ConditionalPNodeCuda(int inode, int igene, double x[])
+{
+   int n = com.ncode, i, h, g, nset = 0;
+   int pos0 = com.posG[igene], pos1 = com.posG[igene + 1];
+
+   if (PMatCudaBuildTopology()) return -1;
+
+   for (i = 0; i < tree.nnode; i++)
+      if (nodes[i].nson > 0)
+         work_dst[nset++] = (size_t)(nodes[i].conP - com.conP);
+   for (i = 0; i < n_fold; i++) {
+      int ison = fold_son[i];
+      work[i].dst = (size_t)(nodes[fold_par[i]].conP - com.conP);
+      work[i].pslot = ison;
+      if (nodes[ison].nson < 1) { work[i].tip = ison; work[i].src = 0; }
+      else { work[i].tip = -1;
+             work[i].src = (size_t)(nodes[ison].conP - com.conP); }
+   }
+   for (i = 0; i < n_scale; i++) {
+      work_sdst[i] = (size_t)(nodes[scale_node[i]].conP - com.conP);
+      work_slot[i] = scale_k[i];
+   }
+
+   if (ConPCudaUploadDst(work_dst, nset) ||
+       ConPCudaUploadWork(work, n_fold) ||
+       ConPCudaUploadScale(work_sdst, work_slot, n_scale))
+      return -1;
+
+   ConPCudaSetFrom(0, nset, n, pos0, pos1, 1.0);   /* every interior node to 1 */
+   for (g = 0, i = 0; g < n_grp; g++) {
+      ConPCudaFoldFrom(grp_start[g], grp_count[g], n, pos0, pos1, com.npatt,
+                       com.cleandata);
+      if (g + 1 < n_grp && grp_lvl[g + 1] == grp_lvl[g]) continue;
+      /* this height is complete: scale it before the next height reads it,
+         which is where ConditionalPNode calls NodeScale */
+      while (i < n_sgrp && sgrp_lvl[i] == grp_lvl[g]) {
+         ConPCudaScaleFrom(sgrp_start[i], sgrp_count[i], n, pos0, pos1,
+                           com.npatt);
+         i++;
+      }
+   }
+
+   /* One fetch for every scaled node, at the end: each is a synchronization. */
+   if (com.NnodeScale) {
+      if (ConPCudaFetchScale(pcache_max, com.NnodeScale, com.npatt)) return -1;
+      for (i = 0; i < n_scale; i++) {
+         int k = scale_k[i];
+         for (h = pos0; h < pos1; h++)
+            com.nodeScaleF[(size_t)k * com.npatt + h] =
+               (pcache_max[(size_t)k * com.npatt + h] < 1e-300
+                  ? -800 : log(pcache_max[(size_t)k * com.npatt + h]));
+      }
+   }
+   return 0;
+}
+
+/* com.conP is authoritative again. Costs one copy of the whole mirror, made
+   only when a host path needs interior conP, not per traversal. */
+void PMatCudaSyncConP(void)
+{
+   if (!conp_dirty) return;
+   conp_dirty = 0;
+   if (ConPCudaSyncToHost(com.conP, com.sconP))
+      zerror("conP sync from device failed");
+}
+
+/* Runs the traversal on the device. Returns 0 if it did, so the caller skips
+   ConditionalPNode; non-zero leaves the C path to redo it. */
+int ConditionalPNodeCudaTraversal(int inode, int igene, double x[])
+{
+   size_t off;
+
+   if (!conp_resident) return -1;
+   if (ConditionalPNodeCuda(inode, igene, x) || ConPCudaCheck()) {
+      /* A partly written mirror cannot be trusted, and neither can com.conP,
+         which the device has been writing instead of the host. Recover the
+         mirror so the C path has somewhere consistent to start from. */
+      conp_dirty = 1;
+      PMatCudaSyncConP();
+      conp_resident = 0;
+      return -1;
+   }
+   conp_dirty = 1;
+
+#ifdef VERIFY_CONP
+   /* Run the C traversal over the same inputs and compare every conP element
+      and every scale factor. Identical output files show the two agree at the
+      optimum; this shows they agree at every call, which is the claim. */
+   {
+      static double *ref = NULL, *refF = NULL;
+      static size_t refsz = 0, refFsz = 0;
+      static long long nchk = 0, nbad = 0, ncall = 0;
+      size_t nel = com.sconP / sizeof(double), nF;
+      size_t i, k;
+
+      nF = (size_t)com.NnodeScale * com.npatt;
+      if (refsz < nel) { free(ref); ref = (double*)malloc(nel * sizeof(double)); refsz = nel; }
+      if (refFsz < nF) { free(refF); refF = (double*)malloc((nF ? nF : 1) * sizeof(double)); refFsz = nF; }
+      if (!ref || (nF && !refF)) zerror("oom in VERIFY_CONP");
+
+      if (ConPCudaSyncToHost(ref, com.sconP)) zerror("VERIFY_CONP sync");
+      for (i = 0; i < nF; i++) refF[i] = com.nodeScaleF[i];
+
+      conp_dirty = 0;             /* keep the C path from restoring the mirror */
+      ConditionalPNode(inode, igene, x);
+
+      for (k = com.ns; k < (size_t)tree.nnode; k++) {
+         size_t o = (size_t)(nodes[k].conP - com.conP);
+         for (i = (size_t)com.posG[igene] * com.ncode;
+              i < (size_t)com.posG[igene + 1] * com.ncode; i++, nchk++)
+            if (memcmp(&ref[o + i], &nodes[k].conP[i], sizeof(double)) != 0) {
+               if (nbad++ < 4)
+                  printf("\nVERIFY_CONP node %d elem %zu: gpu %.17g cpu %.17g",
+                         (int)k, i, ref[o + i], nodes[k].conP[i]);
+            }
+      }
+      for (i = 0; i < nF; i++, nchk++)
+         if (memcmp(&refF[i], &com.nodeScaleF[i], sizeof(double)) != 0)
+            if (nbad++ < 4)
+               printf("\nVERIFY_CONP scaleF %zu: gpu %.17g cpu %.17g",
+                      i, refF[i], com.nodeScaleF[i]);
+
+      if ((++ncall % 2000) == 0 || nbad)
+         printf("\nVERIFY_CONP: %lld traversals, %lld doubles, %lld differ",
+                ncall, nchk, nbad);
+      return 0;                   /* com.conP already holds the C result */
+   }
+#endif
+
+   /* Only the root block is read on the host, by fx_r and lfun. */
+   off = (size_t)(nodes[tree.root].conP - com.conP);
+   if (ConPCudaFetch(nodes[tree.root].conP, off, (size_t)com.npatt * com.ncode)) {
+      PMatCudaSyncConP();
+      conp_resident = 0;
+      return -1;
+   }
+   return 0;
+}
+
+/* Called before a traversal. Leaves pmat_cache_live 0 if the batch could not
+   be built, in which case GetPMatBranch keeps the C path. */
+void PMatCudaBeginTraversal(double x[], int igene)
+{
+   int resident;
+
+   pmat_cache_live = 0;
+   conp_resident = 0;
+
+   /* Same restriction as PMatCudaFillCache: only the codon branch and
+      branch-site models fail to share U/V/Root. */
+   resident = !getenv("PAML_NO_CUDA") && PMatCudaAvailable() &&
+              !(com.seqtype == CODONseq && com.model != 0) && !com.clock &&
+              !(com.seqtype == AAseq && com.model == Poisson) &&
+              com.conP != NULL && com.sconP > 0 && PMatCudaTreeOK() &&
+              ConPCudaResize(com.sconP, tree.nnode, com.ns, com.npatt,
+                             com.ncode, com.NnodeScale) == 0;
+   if (resident && !tips_uploaded) {
+      if (ConPCudaUploadTips((const char *const *)com.z, com.ns, com.npatt,
+                             nChara, (const char *)CharaMap) == 0)
+         tips_uploaded = 1;
+      else
+         resident = 0;
+   }
+   /* The C path is about to read com.conP, so it must be current. */
+   if (!resident) PMatCudaSyncConP();
+
+   if (!PMatCudaFillCache(x, igene, resident)) {
+      PMatCudaSyncConP();
+      return;
+   }
+   pmat_cache_base = pcache;
+   pmat_cache_flag = pcache_ok;
+   pmat_cache_n = com.ncode;
+   pmat_cache_live = !resident;   /* resident keeps P on the device */
+   conp_resident = resident;
+}
+
+void PMatCudaEndTraversal(void)
+{
+   pmat_cache_live = 0;
+   conp_resident = 0;
+}
+
+#endif  /* ENABLE_CUDA */
+
 int ConditionalPNode(int inode, int igene, double x[])
 {
    int n = com.ncode, i, j, k, h, ison, pos0 = com.posG[igene], pos1 = com.posG[igene + 1];
    double t;
+
+#ifdef ENABLE_CUDA
+   /* This reads sons' conP, which the device may have computed. */
+   { extern void PMatCudaSyncConP(void); PMatCudaSyncConP(); }
+#endif
 
    for (i = 0; i < nodes[inode].nson; i++)
       if (nodes[nodes[inode].sons[i]].nson > 0 && !com.oldconP[nodes[inode].sons[i]])

--- a/src/pmatcuda.cu
+++ b/src/pmatcuda.cu
@@ -1,0 +1,461 @@
+/* CUDA backend for PMatUVRoot and ConditionalPNode. See pmatcuda.h. */
+
+#include "pmatcuda.h"
+
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Device buffers, grown as needed and reused across calls. */
+static double *d_P = NULL, *d_exptm1 = NULL, *d_U = NULL, *d_V = NULL;
+static size_t cap_P = 0, cap_exptm1 = 0, cap_U = 0, cap_V = 0;
+static int *d_slot = NULL;          /* batch slot -> node */
+static size_t cap_slot = 0;
+static int checked = 0, available = 0;
+
+/* Resident conditional-probability state. d_conP mirrors com.conP, so a node's
+   block is found at the same offset the host uses, and codeml's per-site-class
+   pointer shift needs no special handling here. */
+static double *d_conP = NULL;
+static size_t cap_conP = 0;
+static char *d_z = NULL;            /* [ns][npatt] tip data */
+static size_t cap_z = 0;
+static char *d_nChara = NULL, *d_CharaMap = NULL;
+static double *d_scaleMax = NULL;
+static size_t cap_scaleMax = 0;
+static ConPWork *d_work = NULL;     /* all (parent, son) pairs, grouped */
+static size_t *d_dst = NULL;        /* interior node offsets */
+static size_t *d_sdst = NULL;       /* scaled node offsets, grouped */
+static int *d_slot2 = NULL;         /* scale slot per scaled node */
+static size_t cap_work = 0, cap_dst = 0, cap_slot2 = 0, cap_sdst = 0;
+static double *h_pin = NULL;        /* staging for fetches */
+static size_t cap_pin = 0;
+
+/* Page-locked staging for U and V. They arrive as PAML's own malloc'd globals,
+   and a pageable H2D costs far more than its size suggests; copying into pinned
+   memory first and sending that is cheaper than letting the driver stage it. */
+static double *h_UV = NULL;
+static size_t cap_hUV = 0;
+
+static int ensure(double **p, size_t *cap, size_t need)
+{
+    if (*cap >= need) return 0;
+    if (*p) cudaFree(*p);
+    if (cudaMalloc(p, need) != cudaSuccess) { *p = NULL; *cap = 0; return -1; }
+    *cap = need;
+    return 0;
+}
+
+static int ensure_raw(void **p, size_t *cap, size_t need)
+{
+    if (*cap >= need) return 0;
+    if (*p) cudaFree(*p);
+    if (cudaMalloc(p, need) != cudaSuccess) { *p = NULL; *cap = 0; return -1; }
+    *cap = need;
+    return 0;
+}
+
+/* Grid is (cells/blockDim, batch): blockIdx.y selects the matrix, blockIdx.x a
+   chunk of its n*n outputs. One block per matrix would launch only `batch`
+   blocks, which leaves most of the device idle at codeml's batch of ~23 and
+   makes each thread walk many cells serially; splitting the cells widens the
+   grid by ceil(n*n/blockDim) so a small batch still fills the SMs.
+   Output goes to slot[b]'s node block, so the result is already in the layout
+   the traversal reads and no host-side scatter is needed.
+   exptm1[k] is hoisted out of the i loop as PAML does. Accumulation runs over k
+   in PAML's order so the rounding matches. */
+__global__ void KPMatUVRoot(double *Pall, const double *Eall, const double *Uall,
+                            const double *Vall, const int *slot,
+                            int n, int ustride, int vstride)
+{
+    extern __shared__ double sh[];
+    double *e = sh;
+
+    int b = blockIdx.y;
+    const double *U = Uall + (size_t)b * ustride;
+    const double *V = Vall + (size_t)b * vstride;
+    const double *E = Eall + (size_t)b * n;
+    double *P = Pall + (size_t)(slot ? slot[b] : b) * n * n;
+
+    for (int k = threadIdx.x; k < n; k += blockDim.x)
+        e[k] = E[k];
+    __syncthreads();
+
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n * n) return;
+
+    int i = idx / n, j = idx % n;
+    double acc = 0.0;
+    for (int k = 0; k < n; k++)
+        acc += (U[i * n + k] * e[k]) * V[k * n + j];
+    if (i == j) acc += 1.0;          /* PAML: P[i*n+i]++ after the sum */
+    P[idx] = acc < 0.0 ? 0.0 : acc;  /* PAML: if (P[i] < smallp) P[i] = 0 */
+}
+
+int PMatCudaAvailable(void)
+{
+    int count = 0;
+    if (checked) return available;
+    checked = 1;
+    if (cudaGetDeviceCount(&count) == cudaSuccess && count > 0)
+        available = 1;
+    return available;
+}
+
+int PMatUVRootBatchCuda(double *P, const double *exptm1, const double *U,
+                        const double *V, int n, int batch,
+                        int ustride, int vstride)
+{
+    return PMatUVRootBatchCudaSlot(P, exptm1, U, V, NULL, n, batch,
+                                   ustride, vstride, 0);
+}
+
+int PMatUVRootBatchCudaSlot(double *P, const double *exptm1, const double *U,
+                            const double *V, const int *slot, int n, int batch,
+                            int ustride, int vstride, int keep_on_device)
+{
+    size_t mat = (size_t)n * n;
+    size_t nU, nV, nP;
+    int maxnode = batch;
+
+    if (!PMatCudaAvailable() || batch <= 0 || n <= 0) return -1;
+
+    if (slot) {
+        maxnode = 0;
+        for (int i = 0; i < batch; i++)
+            if (slot[i] + 1 > maxnode) maxnode = slot[i] + 1;
+    }
+    nP = mat * maxnode * sizeof(double);
+
+    /* stride 0 means one matrix shared by the whole batch */
+    nU = (ustride ? (size_t)ustride * batch : mat) * sizeof(double);
+    nV = (vstride ? (size_t)vstride * batch : mat) * sizeof(double);
+
+    if (ensure(&d_P, &cap_P, nP) ||
+        ensure(&d_exptm1, &cap_exptm1, (size_t)n * batch * sizeof(double)) ||
+        ensure(&d_U, &cap_U, nU) || ensure(&d_V, &cap_V, nV))
+        return -1;
+    if (slot) {
+        if (ensure_raw((void **)&d_slot, &cap_slot, (size_t)batch * sizeof(int)))
+            return -1;
+        if (cudaMemcpy(d_slot, slot, (size_t)batch * sizeof(int),
+                       cudaMemcpyHostToDevice) != cudaSuccess)
+            return -1;
+    }
+
+    if (cudaMemcpy(d_exptm1, exptm1, (size_t)n * batch * sizeof(double),
+                   cudaMemcpyHostToDevice) != cudaSuccess)
+        return -1;
+
+    /* Stage U and V through page-locked memory. */
+    if (cap_hUV < nU + nV) {
+        if (h_UV) cudaFreeHost(h_UV);
+        if (cudaHostAlloc(&h_UV, nU + nV, cudaHostAllocDefault) != cudaSuccess) {
+            h_UV = NULL; cap_hUV = 0;
+        } else {
+            cap_hUV = nU + nV;
+        }
+    }
+    if (h_UV) {
+        memcpy(h_UV, U, nU);
+        memcpy((char *)h_UV + nU, V, nV);
+        if (cudaMemcpy(d_U, h_UV, nU, cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(d_V, (char *)h_UV + nU, nV, cudaMemcpyHostToDevice) != cudaSuccess)
+            return -1;
+    } else {
+        if (cudaMemcpy(d_U, U, nU, cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(d_V, V, nV, cudaMemcpyHostToDevice) != cudaSuccess)
+            return -1;
+    }
+
+    {
+        int thr = 256;
+        dim3 grd((n * n + thr - 1) / thr, batch);
+        KPMatUVRoot<<<grd, thr, n * sizeof(double)>>>(
+            d_P, d_exptm1, d_U, d_V, slot ? d_slot : NULL, n,
+            ustride ? ustride : 0, vstride ? vstride : 0);
+    }
+
+    /* A failed launch leaves d_P holding the previous call's results, which
+       would be copied back and reported as a valid answer. */
+    if (cudaGetLastError() != cudaSuccess) return -1;
+
+    /* The traversal reads P on the device, so the copy back is skipped and P is
+       never returned to the host at all. That copy is 29.8 kB per 227 kflop of
+       work and dominates the end-to-end cost when it is made. */
+    if (!keep_on_device) {
+        /* The D2H copy is stream-ordered after the kernel and blocks until it
+           has completed, so no separate device sync is needed. */
+        if (cudaMemcpy(P, d_P, nP, cudaMemcpyDeviceToHost) != cudaSuccess)
+            return -1;
+    }
+    return 0;
+}
+
+/* ---- resident ConditionalPNode ------------------------------------------ */
+
+/* Nodes at the same height are independent, so one launch covers all of them:
+   blockIdx.y picks the work item, blockIdx.x a chunk of that node's outputs.
+   A launch per node per son would issue ~570 launches per traversal on a
+   192-taxon tree, each only 48 blocks against 142 SMs, which leaves the device
+   idle and makes launch overhead the limit rather than arithmetic. */
+
+/* conP[h*n+j] = val over every node in dst. */
+__global__ void KConPSetMany(double *conP, const size_t *dst, int n,
+                             int pos0, int pos1, double val)
+{
+    size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    size_t total = (size_t)(pos1 - pos0) * n;
+    if (i >= total) return;
+    conP[dst[blockIdx.y] + (size_t)pos0 * n + i] = val;
+}
+
+/* Folds one son into its parent, for every (parent, son) pair in w. Pairs in
+   one launch have distinct parents, so the read-modify-write cannot race; the
+   sons of a single parent go in separate launches, in PAML's order. */
+__global__ void KConPFold(double *conP, const double *Pall, const char *z,
+                          const char *nChara, const char *CharaMap,
+                          const ConPWork *w, int n, int pos0, int pos1,
+                          int npatt, int cleandata)
+{
+    size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    size_t total = (size_t)(pos1 - pos0) * n;
+    if (i >= total) return;
+
+    ConPWork it = w[blockIdx.y];
+    int h = pos0 + (int)(i / n), j = (int)(i % n);
+    const double *PMat = Pall + (size_t)it.pslot * n * n;
+    const double *pr = PMat + (size_t)j * n;
+    double t;
+
+    if (it.tip >= 0) {
+        unsigned char c = (unsigned char)z[(size_t)it.tip * npatt + h];
+        if (cleandata) {
+            t = pr[c];                       /* PMat[j*n + z[h]] */
+        } else {
+            int nc = (int)(unsigned char)nChara[c];
+            t = 0;
+            for (int k = 0; k < nc; k++)
+                t += pr[(unsigned char)CharaMap[(size_t)c * 64 + k]];
+        }
+    } else {
+        const double *cs = conP + it.src + (size_t)h * n;
+        t = 0;
+        for (int k = 0; k < n; k++)          /* PAML's k order */
+            t += pr[k] * cs[k];
+    }
+    conP[it.dst + (size_t)h * n + j] *= t;
+}
+
+/* One block per (pattern, node): max over states, then divide. max is exact and
+   order-independent, so the reduction shape does not affect the result.
+   log() stays on the host: it is npatt calls against npatt*n divisions, and the
+   device log does not agree with the host libm in the last bit. */
+__global__ void KNodeScaleMany(double *conP, const size_t *dst, const int *slot,
+                               double *out, int n, int pos0, int pos1, int npatt)
+{
+    extern __shared__ double red[];
+    int h = pos0 + blockIdx.x;
+    if (h >= pos1) return;
+    double *c = conP + dst[blockIdx.y] + (size_t)h * n;
+
+    double m = 0;
+    for (int j = threadIdx.x; j < n; j += blockDim.x)
+        if (c[j] > m) m = c[j];
+    red[threadIdx.x] = m;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s && red[threadIdx.x + s] > red[threadIdx.x])
+            red[threadIdx.x] = red[threadIdx.x + s];
+        __syncthreads();
+    }
+    m = red[0];
+
+    if (m < 1e-300) {
+        for (int j = threadIdx.x; j < n; j += blockDim.x) c[j] = 1.0;
+    } else {
+        for (int j = threadIdx.x; j < n; j += blockDim.x) c[j] /= m;
+    }
+    if (threadIdx.x == 0) out[(size_t)slot[blockIdx.y] * npatt + h] = m;
+}
+
+int ConPCudaResize(size_t sconP, int nnode, int ns, int npatt, int n,
+                   int nscale)
+{
+    size_t nw = (size_t)nnode;
+    if (!PMatCudaAvailable()) return -1;
+    if (ensure(&d_conP, &cap_conP, sconP)) return -1;
+    if (ensure(&d_P, &cap_P, (size_t)nnode * n * n * sizeof(double))) return -1;
+    if (ensure(&d_scaleMax, &cap_scaleMax,
+               (size_t)(nscale ? nscale : 1) * npatt * sizeof(double)))
+        return -1;
+    if (ensure_raw((void **)&d_z, &cap_z, (size_t)ns * npatt)) return -1;
+    if (ensure_raw((void **)&d_work, &cap_work, 2 * nw * sizeof(ConPWork)) ||
+        ensure_raw((void **)&d_dst, &cap_dst, nw * sizeof(size_t)) ||
+        ensure_raw((void **)&d_sdst, &cap_sdst, nw * sizeof(size_t)) ||
+        ensure_raw((void **)&d_slot2, &cap_slot2, nw * sizeof(int)))
+        return -1;
+    if (d_nChara == NULL &&
+        (cudaMalloc(&d_nChara, 256) != cudaSuccess ||
+         cudaMalloc(&d_CharaMap, (size_t)256 * 64) != cudaSuccess))
+        return -1;
+    if (cap_pin < (size_t)npatt * n * sizeof(double)) {
+        if (h_pin) cudaFreeHost(h_pin);
+        if (cudaHostAlloc(&h_pin, (size_t)npatt * n * sizeof(double),
+                          cudaHostAllocDefault) != cudaSuccess) {
+            h_pin = NULL; cap_pin = 0; return -1;
+        }
+        cap_pin = (size_t)npatt * n * sizeof(double);
+    }
+    return 0;
+}
+
+int ConPCudaUploadTips(const char *const *z, int ns, int npatt,
+                       const char *nChara, const char *CharaMap)
+{
+    for (int i = 0; i < ns; i++)
+        if (cudaMemcpy(d_z + (size_t)i * npatt, z[i], npatt,
+                       cudaMemcpyHostToDevice) != cudaSuccess)
+            return -1;
+    if (cudaMemcpy(d_nChara, nChara, 256, cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_CharaMap, CharaMap, (size_t)256 * 64,
+                   cudaMemcpyHostToDevice) != cudaSuccess)
+        return -1;
+    return 0;
+}
+
+#define GRID(total) (int)(((total) + 255) / 256)
+
+/* The work lists go up once per traversal, not once per launch. A staged copy
+   out of pageable memory costs ~15 us regardless of size, so uploading per
+   launch cost more on a shallow tree than the batching saved. */
+int ConPCudaUploadWork(const ConPWork *w, int nw)
+{
+    if (nw <= 0) return 0;
+    return cudaMemcpy(d_work, w, (size_t)nw * sizeof(ConPWork),
+                      cudaMemcpyHostToDevice) == cudaSuccess ? 0 : -1;
+}
+
+int ConPCudaUploadDst(const size_t *dst, int nw)
+{
+    if (nw <= 0) return 0;
+    return cudaMemcpy(d_dst, dst, (size_t)nw * sizeof(size_t),
+                      cudaMemcpyHostToDevice) == cudaSuccess ? 0 : -1;
+}
+
+int ConPCudaUploadScale(const size_t *dst, const int *slot, int nw)
+{
+    if (nw <= 0) return 0;
+    if (cudaMemcpy(d_sdst, dst, (size_t)nw * sizeof(size_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_slot2, slot, (size_t)nw * sizeof(int),
+                   cudaMemcpyHostToDevice) != cudaSuccess)
+        return -1;
+    return 0;
+}
+
+/* start indexes the arrays uploaded above; nw is that group's length. */
+void ConPCudaSetFrom(int start, int nw, int n, int pos0, int pos1, double val)
+{
+    size_t total = (size_t)(pos1 - pos0) * n;
+    if (nw <= 0 || total == 0) return;
+    { dim3 g(GRID(total), nw);
+      KConPSetMany<<<g, 256>>>(d_conP, d_dst + start, n, pos0, pos1, val); }
+}
+
+void ConPCudaFoldFrom(int start, int nw, int n, int pos0, int pos1,
+                      int npatt, int cleandata)
+{
+    size_t total = (size_t)(pos1 - pos0) * n;
+    if (nw <= 0 || total == 0) return;
+    { dim3 g(GRID(total), nw);
+      KConPFold<<<g, 256>>>(d_conP, d_P, d_z, d_nChara, d_CharaMap,
+                            d_work + start, n, pos0, pos1, npatt, cleandata); }
+}
+
+void ConPCudaScaleFrom(int start, int nw, int n, int pos0, int pos1, int npatt)
+{
+    int nb = pos1 - pos0, thr = 64;
+    if (nw <= 0 || nb <= 0) return;
+    while (thr < n && thr < 256) thr <<= 1;
+    { dim3 g(nb, nw);
+      KNodeScaleMany<<<g, thr, thr * sizeof(double)>>>(
+          d_conP, d_sdst + start, d_slot2 + start, d_scaleMax, n, pos0, pos1,
+          npatt); }
+}
+
+/* Scale maxima for every scaled node, fetched once per traversal rather than
+   once per node: each fetch is a synchronization, and a 192-taxon tree scales
+   at 10 nodes. */
+int ConPCudaFetchScale(double *dst, int nscale, int npatt)
+{
+    if (nscale <= 0) return 0;
+    return cudaMemcpy(dst, d_scaleMax, (size_t)nscale * npatt * sizeof(double),
+                      cudaMemcpyDeviceToHost) == cudaSuccess ? 0 : -1;
+}
+
+int ConPCudaFetch(double *dst, size_t off, size_t nelem)
+{
+    if (cudaGetLastError() != cudaSuccess) return -1;
+    if (h_pin && nelem * sizeof(double) <= cap_pin) {
+        if (cudaMemcpy(h_pin, d_conP + off, nelem * sizeof(double),
+                       cudaMemcpyDeviceToHost) != cudaSuccess)
+            return -1;
+        memcpy(dst, h_pin, nelem * sizeof(double));
+        return 0;
+    }
+    return cudaMemcpy(dst, d_conP + off, nelem * sizeof(double),
+                      cudaMemcpyDeviceToHost) == cudaSuccess ? 0 : -1;
+}
+
+int ConPCudaSyncToHost(double *conP, size_t sconP)
+{
+    if (d_conP == NULL || sconP > cap_conP) return -1;
+    return cudaMemcpy(conP, d_conP, sconP, cudaMemcpyDeviceToHost)
+           == cudaSuccess ? 0 : -1;
+}
+
+int ConPCudaCheck(void)
+{
+    return cudaGetLastError() == cudaSuccess ? 0 : -1;
+}
+
+void *PMatCudaHostAlloc(size_t bytes)
+{
+    void *p = NULL;
+    if (!PMatCudaAvailable()) return NULL;
+    if (cudaHostAlloc(&p, bytes, cudaHostAllocDefault) != cudaSuccess) return NULL;
+    return p;
+}
+
+void PMatCudaHostFree(void *p)
+{
+    if (p) cudaFreeHost(p);
+}
+
+void PMatCudaCleanup(void)
+{
+    if (d_P) cudaFree(d_P);
+    if (d_exptm1) cudaFree(d_exptm1);
+    if (d_U) cudaFree(d_U);
+    if (d_V) cudaFree(d_V);
+    if (d_slot) cudaFree(d_slot);
+    if (d_conP) cudaFree(d_conP);
+    if (d_z) cudaFree(d_z);
+    if (d_nChara) cudaFree(d_nChara);
+    if (d_CharaMap) cudaFree(d_CharaMap);
+    if (d_scaleMax) cudaFree(d_scaleMax);
+    if (d_work) cudaFree(d_work);
+    if (d_dst) cudaFree(d_dst);
+    if (d_sdst) cudaFree(d_sdst);
+    if (d_slot2) cudaFree(d_slot2);
+    if (h_pin) cudaFreeHost(h_pin);
+    if (h_UV) cudaFreeHost(h_UV);
+    d_P = d_exptm1 = d_U = d_V = d_conP = d_scaleMax = NULL;
+    h_pin = h_UV = NULL;
+    d_slot = NULL; d_dst = NULL; d_sdst = NULL; d_slot2 = NULL; d_work = NULL;
+    d_z = d_nChara = d_CharaMap = NULL;
+    cap_P = cap_exptm1 = cap_U = cap_V = cap_slot = 0;
+    cap_conP = cap_z = cap_scaleMax = cap_pin = cap_hUV = 0;
+    cap_work = cap_dst = cap_slot2 = cap_sdst = 0;
+}

--- a/src/pmatcuda.h
+++ b/src/pmatcuda.h
@@ -1,0 +1,146 @@
+/* CUDA backend for codeml's likelihood inner loops.
+ *
+ * Two pieces, both bit-identical to the C they replace:
+ *
+ *   PMatUVRoot      P(t) = U * exp{Root*t} * V          (tools.c:516)
+ *   ConditionalPNode  the post-order traversal          (codeml.c:3690)
+ *
+ * PMatUVRoot alone is 39k-65k calls of a 61x61x61 dense double product per
+ * codeml run on examples/HIVNSsites, and it is the whole cost on small trees.
+ * On large trees it is not: at 192 taxa the traversal's own GEMM
+ * (npatt x n x n per internal node) dominates, and returning P to the host
+ * costs more than computing it there. Keeping P and conP resident removes both
+ * the copy and the traversal's arithmetic.
+ *
+ * Results are bit-identical because every accumulation runs in PAML's own
+ * order, one thread per output cell. expm1 and log stay on the host: each is
+ * called n or npatt times against n^3 or npatt*n^2 for the products, so moving
+ * them saves nothing, and CUDA's expm1 and log do not agree with the host libm
+ * in the last bit.
+ */
+
+#ifndef PMATCUDA_H
+#define PMATCUDA_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Non-zero if a usable device was found. Checked once; the caller falls back
+   to the C path when this returns 0. */
+int PMatCudaAvailable(void);
+
+/* Batched P(t). Computes batch matrices of size n*n into P.
+ *
+ *   P     [batch][n*n]   output, row-major, as PMatUVRoot writes it
+ *   exptm1[batch][n]     expm1(t*Root[k]) computed by the caller on the host
+ *   U     [batch][n*n]   right eigenvectors
+ *   V     [batch][n*n]   inverse eigenvectors
+ *
+ * U and V may be shared across the batch; pass ustride/vstride 0 to reuse a
+ * single matrix for every entry, which is the common case since eigenQcodon
+ * runs far less often than P(t).
+ *
+ * Returns 0 on success, non-zero on a CUDA error, in which case P is
+ * untouched and the caller should use the C path.
+ */
+int PMatUVRootBatchCuda(double *P, const double *exptm1, const double *U,
+                        const double *V, int n, int batch,
+                        int ustride, int vstride);
+
+/* As above, with two additions used by the resident traversal:
+ *
+ *   slot[batch]      writes matrix b to P + slot[b]*n*n instead of P + b*n*n,
+ *                    so results land indexed by node and need no host scatter.
+ *                    NULL keeps the plain batch layout.
+ *   keep_on_device   non-zero skips the copy back; P is left on the device for
+ *                    ConPCuda* to read, and the host pointer is untouched.
+ */
+int PMatUVRootBatchCudaSlot(double *P, const double *exptm1, const double *U,
+                            const double *V, const int *slot, int n, int batch,
+                            int ustride, int vstride, int keep_on_device);
+
+/* Resident ConditionalPNode.
+ *
+ * ConPCudaResize mirrors com.conP on the device: a node's block sits at the
+ * same offset the host uses, so codeml's per-site-class pointer shift needs no
+ * translation. All offsets below are element offsets into that mirror,
+ * i.e. nodes[i].conP - com.conP.
+ *
+ * Work is issued a tree level at a time. Nodes at the same height are
+ * independent, so one launch covers all of them and the grid is wide enough to
+ * fill the device; per-node launches are too small to do either.
+ *
+ * The calls are launches only and do not synchronize; ConPCudaCheck reports any
+ * error since the last check, and the fetches synchronize implicitly.
+ */
+
+/* One (parent, son) fold. Pairs handed to ConPCudaFold together must have
+   distinct parents, since each writes its parent's block. */
+typedef struct {
+   size_t dst;    /* parent conP offset */
+   size_t src;    /* son conP offset; unused when tip >= 0 */
+   int pslot;     /* son node index, selects its P(t) */
+   int tip;       /* tip index into z, or -1 if the son is internal */
+} ConPWork;
+
+int ConPCudaResize(size_t sconP, int nnode, int ns, int npatt, int n,
+                   int nscale);
+
+/* Tip data, uploaded once per alignment. CharaMap is the flat [256][64] map. */
+int ConPCudaUploadTips(const char *const *z, int ns, int npatt,
+                       const char *nChara, const char *CharaMap);
+
+/* The work lists go up once per traversal; the launchers then index into them
+   by group. Uploading per launch costs more than the batching saves, since a
+   staged copy out of pageable memory is ~15 us regardless of size. Buffers
+   passed here should be page-locked. */
+int ConPCudaUploadWork(const ConPWork *w, int nw);
+int ConPCudaUploadDst(const size_t *dst, int nw);
+int ConPCudaUploadScale(const size_t *dst, const int *slot, int nw);
+
+/* conP[h*n+j] = val for dst[start .. start+nw). */
+void ConPCudaSetFrom(int start, int nw, int n, int pos0, int pos1, double val);
+
+/* Folds w[start .. start+nw). Those pairs must have distinct parents; the sons
+   of one parent go in separate calls, in PAML's order. cleandata selects the
+   observed-state lookup over the ambiguity sum, matching ConditionalPNode's two
+   tip branches. */
+void ConPCudaFoldFrom(int start, int nw, int n, int pos0, int pos1,
+                      int npatt, int cleandata);
+
+/* Scales as NodeScale does, writing each node's per-pattern maxima to its own
+   row of the maxima buffer. */
+void ConPCudaScaleFrom(int start, int nw, int n, int pos0, int pos1, int npatt);
+
+/* All scale maxima, nscale*npatt doubles, from which the caller takes log(). */
+int ConPCudaFetchScale(double *dst, int nscale, int npatt);
+
+/* nelem doubles from the mirror at off. Used for the root block, the only part
+   of conP the likelihood consumes on the host. */
+int ConPCudaFetch(double *dst, size_t off, size_t nelem);
+
+/* Whole mirror back to com.conP. Used once when the device stops owning conP,
+   so host paths that read interior nodes see current values. */
+int ConPCudaSyncToHost(double *conP, size_t sconP);
+
+/* 0 if no CUDA error is pending. */
+int ConPCudaCheck(void);
+
+/* Page-locked host memory. Transfers from pageable memory stage through a
+   driver bounce buffer, which dominates the cost at these batch sizes; buffers
+   handed to PMatUVRootBatchCuda should come from here. Returns NULL on
+   failure, in which case ordinary malloc still works, only slower. */
+void *PMatCudaHostAlloc(size_t bytes);
+void PMatCudaHostFree(void *p);
+
+/* Frees device buffers. Safe to call when nothing was allocated. */
+void PMatCudaCleanup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/treesub.c
+++ b/src/treesub.c
@@ -5174,7 +5174,11 @@ int MultipleGenes(FILE* fout, FILE* ftree, FILE* fpair[], double space[])
     in baseml and codeml.
     */
    int ig = 0, j, ngene0, npatt0, lgene0[NGENE] = { 0 }, posG0[NGENE + 1] = {0};
-   int nb = ((com.seqtype == 1 && !com.cleandata) ? 3 : 1);
+   /* One byte per pattern. EncodeSeqs collapses codons to a single code
+      whether or not the data are clean, giving each ambiguous codon its own
+      entry in CODONs[], and reallocs com.z[] to com.npatt; a stride of 3 for
+      unclean codon data walks off the end of it. */
+   int nb = 1;
 
    if (com.ndata > 1) zerror("multiple data sets & multiple genes?");
 
@@ -7585,6 +7589,22 @@ int GetPMatBranch(double Pt[], double x[], double t, int inode)
       PMatJC69like(Pt, t, com.ncode);
    else {
       t *= Qfactor;
+#ifdef ENABLE_CUDA
+      /* PMatCudaBeginTraversal batches every branch of this traversal into one
+         kernel call; take the result rather than recompute it here. */
+      {
+         extern int pmat_cache_live, pmat_cache_n;
+         extern double *pmat_cache_base;
+         extern char *pmat_cache_flag;
+         if (pmat_cache_live && pmat_cache_flag[inode]) {
+            double *cached = pmat_cache_base +
+                             (size_t)inode * pmat_cache_n * pmat_cache_n;
+            memcpy(Pt, cached,
+                   (size_t)pmat_cache_n * pmat_cache_n * sizeof(double));
+            return(0);
+         }
+      }
+#endif
       PMatUVRoot(Pt, t, com.ncode, U, V, Root);
    }
 
@@ -7721,7 +7741,20 @@ int fx_r(double x[], int np)
                nodes[i].conP += (size_t)(tree.nnode - com.ns) * com.ncode * com.npatt;
          }
          SetPSiteClass(ir, x);
+#ifdef ENABLE_CUDA
+         { extern void PMatCudaBeginTraversal(double*, int);
+           extern int ConditionalPNodeCudaTraversal(int, int, double*);
+           extern void PMatCudaEndTraversal(void);
+           PMatCudaBeginTraversal(x, ig);
+           /* The device runs the whole traversal when it holds conP;
+              otherwise it declined and the C path does it. */
+           if (ConditionalPNodeCudaTraversal(tree.root, ig, x))
+              ConditionalPNode(tree.root, ig, x);
+           PMatCudaEndTraversal();
+         }
+#else
          ConditionalPNode(tree.root, ig, x);
+#endif
 
          for (h = com.posG[ig]; h < com.posG[ig + 1]; h++) {
             if (com.fpatt[h] <= 0 && com.print >= 0) continue;
@@ -7773,7 +7806,20 @@ double lfun(double x[], int np)
    for (ig = 0; ig < com.ngene; ig++) {
       if (com.Mgene > 1)
          SetPGene(ig, 1, 1, 0, x);
+#ifdef ENABLE_CUDA
+      { extern void PMatCudaBeginTraversal(double*, int);
+        extern int ConditionalPNodeCudaTraversal(int, int, double*);
+        extern void PMatCudaEndTraversal(void);
+        PMatCudaBeginTraversal(x, ig);
+        /* The device runs the whole traversal when it holds conP;
+           otherwise it declined and the C path does it. */
+        if (ConditionalPNodeCudaTraversal(tree.root, ig, x))
+           ConditionalPNode(tree.root, ig, x);
+        PMatCudaEndTraversal();
+      }
+#else
       ConditionalPNode(tree.root, ig, x);
+#endif
 
       for (h = com.posG[ig]; h < com.posG[ig + 1]; h++) {
          if (com.fpatt[h] <= 0 && com.print >= 0) continue;
@@ -9095,17 +9141,18 @@ int GenerateGtree_locus(int locus, int ns, int allocate_gnodes)
    com.ns = ns;
    NodeToBranch();
 
-#if(MCMCTREE)
+   /* Not MCMCTREE-only. baseml and codeml reach here under clock = 5 and 6,
+      through DatingHeteroData and ReadTreeSeqs. GetMemBC then indexes
+      gnodes[locus], and the AHRS rate smoothing reads stree.nodes[ipop].age
+      for each tip, so both halves are needed outside mcmctree. */
    for (i = 0; i < stree.nnode; i++)
       if (newnodeNO[i] != -1) nodes[newnodeNO[i]].ipop = i;
-   /* printGtree(0);  */
    if (allocate_gnodes) {
       gnodes[locus] = (struct TREEN*)malloc((ns * 2 - 1) * sizeof(struct TREEN));
       if (gnodes[locus] == NULL) zerror("oom gtree");
       memcpy(gnodes[locus], nodes, (ns * 2 - 1) * sizeof(struct TREEN));
       data.root[locus] = tree.root;
    }
-#endif
    free(newnodeNO);
    return(0);
 }


### PR DESCRIPTION
Moves the two dense inner loops of the codon likelihood to the GPU: `PMatUVRoot` (`tools.c:516`), n^3 per branch, and `ConditionalPNode`, npatt·n^2 per internal node. Off unless built with `CUDA=1`. `tools.c` is untouched and every other program is unaffected.

## Results

Same binary in both arms, `PAML_NO_CUDA=1` for the C arm, seed pinned, each process pinned to one core. Both test hosts are hybrid CPUs; an unpinned single-threaded run migrates between P- and E-cores and moves the wall clock by up to 1.4x, which is larger than several of the effects below.

RTX 6000 Ada (sm_89), MSVC `/O2`:

| example | taxa | codons | C | CUDA | |
| --- | --- | --- | --- | --- | --- |
| HIVNSsites | 13 | 91 | 19.33 s | 7.41 s | 2.61x |
| lysin | 25 | 135 | 104.67 s | 17.28 s | 6.06x |
| MHC.Swanson2002MBE | 192 | 270 | 204.20 s | 11.71 s | 17.43x |
| CladeModelCD | 15 | 161 | 26.89 s | 26.95 s | declines |

RTX 3070 Ti (sm_86), gcc `-O3`:

| example | taxa | codons | C | CUDA | |
| --- | --- | --- | --- | --- | --- |
| HIVNSsites | 13 | 91 | 21.23 s | 7.32 s | 2.90x |
| lysin | 25 | 135 | 115.85 s | 22.37 s | 5.18x |
| MHC.Swanson2002MBE | 192 | 270 | 219.80 s | 26.90 s | 8.17x |

Amino acid data, `examples/MouseLemurs` (35 taxa, 604 sites), JTT + gamma: 2.08 s -> 1.35 s. The kernels are smaller there, n = 20 rather than 61.

`mlc`, `rst` and `lnf` are byte-identical in every case, with identical `lfun` and `eigenQcodon` counters and zero host-side P(t) calls.

The gain tracks tree size because the two loops scale differently: P(t) is n^3 per branch and independent of the alignment, the traversal is npatt·n^2 per internal node and grows with both. At 192 taxa the traversal dominates and returning P to the host costs more than computing it, so porting either loop alone loses at one end or the other.

## Bit-exactness

Every accumulation runs in PAML's own k-order, one thread per output cell, so no reassociation occurs. Three requirements:

- `-fmad=false`, in the nvcc rule. FMA contraction changes the rounding of the multiply-accumulate.
- `expm1` stays on the host. CUDA's disagrees with libm in the last bit, and it is n = 61 calls per matrix against n^3 = 226,981 for the product.
- `log` stays on the host. `NodeScale` reduces to a per-pattern maximum on the device and returns the maxima; `max` is exact and order-independent, so the reduction shape does not matter.

`-DVERIFY_CONP` builds a codeml that runs both traversals over the same inputs and compares every conP element and every scale factor with `memcmp`:

| example | traversals | doubles compared | differ |
| --- | --- | --- | --- |
| HIVNSsites | 12,000 | 636,108,000 | 0 |
| lysin | 24,000 | 4,444,704,000 | 0 |
| MHC.Swanson2002MBE | 4,000 | 8,816,000,000 | 0 |
| HIVNSsites, `seqtype = 2` | 6,000 | 109,560,000 | 0 |

Identical output files show the two agree at the optimum; this shows they agree at every call. The C arm computes its own P(t) through `PMatUVRoot`, so the comparison covers the whole chain. lysin exercises the ambiguity path (`cleandata = 0`); MHC exercises `NodeScale`, which selects 10 nodes on that tree; the last row exercises n = 20 rather than 61.

Beyond that, 32 configurations were run twice through one binary, `PAML_NO_CUDA=1` against the device path, diffing every output file: `method = 1` (which turns on `conPSiteClass` and the per-class conP shift, and declines the `minbranches` traversals), `RateAncestor = 1` and `2` (which read interior conP and so force the mirror back to the host), `runmode = 1` (tree search, where `ReRootTree` rewrites the topology), `runmode = -2`, `seqtype = 2` and `3`, every `CodonFreq` including `FMutSel`, `NSsites` 0/1/2/3/7/8, `Mgene` 0/2/3/4 on a partitioned alignment, `clock`, `icode`, `fix_blength`, `getSE`. All identical.

The kernel carries no architecture dependence. Fed one host's `expm1` values, sm_86 reproduces sm_89's result bit for bit (FNV-1a `402d230b0d693211` on both). The two hosts otherwise differ from each other only because MSVC's and glibc's `expm1` differ in the last bit, which is already true of unmodified codeml.

## Design

`com.conP` is mirrored on the device at the host's own offsets, so the per-site-class pointer shift in `fx_r` needs no translation. P is written into a node-indexed device buffer and never copied back; only the root block returns, which is what `fx_r` and `lfun` read. When a host path needs interior conP the mirror is copied back once at that point, from `ConditionalPNode`.

Work is issued one tree height at a time. Nodes of equal height are independent, so one launch covers all of them. Per-node launches issued ~570 kernels per traversal on the 192-taxon tree, each only 48 blocks against 142 SMs, which left the device idle behind launch overhead.

## What it declines

Falls back to the C path, checked per traversal:

| condition | reason |
| --- | --- |
| `com.seqtype == CODONseq && com.model != 0` | the codon branch and branch-site models point U/V/Root at per-branch tables in `GetPMatBranch`, so a traversal does not share them. Every such case there is guarded by `CODONseq`; the amino acid models keep the global U/V/Root from `eigenQaa` and are handled |
| `com.clock` | branch rates come from `GetBranchRate` |
| `com.seqtype == AAseq && com.model == Poisson` | `PMatJC69like`, not `PMatUVRoot` |
| any `com.oldconP[i]` | the caller reuses a subtree the device never computed |
| a node below `com.ns` with sons | a sampled ancestor has no block in `com.conP`, so the mirror cannot index it |
| any CUDA error, including a failed allocation | |

CladeModelCD (`model = 3`) exercises the first; its row above is the cost of the fallback.

The height grouping is keyed on an FNV-1a signature of the topology rather than on `tree.nnode`, since a `.trees` file may hold several trees and `ReRootTree` rewrites father and sons in place, both of which keep the node count.

## Four crashes this turned up

Differential-testing the backend against the C path over every shipped example
and a sweep of control-file settings ran into four pre-existing crashes, each
reproduced on an unpatched clone before being touched. They are fixed here
rather than separately because the CUDA work is what surfaced them, and because
two of them are hit by control files in `examples/`.

**`runmode = 2` writes past `sons[]`.** `MAXNSONS` is 3 in codeml, so
`nodes[].sons[]` holds a trifurcation and nothing wider, but `StarDecomposition`
gives the root `com.ns` sons. On `examples/HIVNSsites` that is 10 int writes
over `ibranch`, `ipop`, and into the next node, and codeml dies in
`ConditionalPNode` reading `nodes[nodes[inode].sons[i]].nson`. baseml has the
same struct and uses 64, evolver 20, pamp and basemlg 10. At 64 the star
decomposition completes (lnL -1223.880, clean under AddressSanitizer) and
`runmode = 0` is unchanged.

**`com.pomega` is offset by an unset branch label.** `DetailOutput` scales
`com.pomega` by `(int)nodes[...].label * com.nOmegaType` under `com.model == 0`
and `FromCodon0`, which are the models with no branch types, so the tree carries
no labels and `ReadTreeN` leaves `label` at -1 (`treesub.c:3071`). On
`examples/mtCDNA/codeml.ctl` (`aaDist = 7`) that puts `com.pomega` at `x - 58`
and `GetOmega` reads `x[-29]`; a plain build dies with "stack smashing
detected". An unlabelled tree is one branch type, so the offset is 0.

**`clock = 5` and `6` never allocate their gene trees.** `GenerateGtree_locus`
keeps both the `ipop` map and the `gnodes[locus]` allocation its own
`allocate_gnodes` argument asks for behind `#if(MCMCTREE)`. baseml and codeml
reach it under `clock = 5` and `6` through `DatingHeteroData` and
`ReadTreeSeqs`, which pass `allocate_gnodes = 1`, so for either program the
block disappears, `gnodes[]` is never filled, and `GetMemBC` dereferences it.
The AHRS rate smoothing also reads `stree.nodes[ipop].age`, so both halves are
needed outside mcmctree; `ipop` and `data.root[]` are declared in codeml.c and
baseml.c. All three shipped `clock = 6` control files segfault before this and
complete after: `baseml2.ctl` (combined lnL -24997.999978), `aaml2.ctl`
(lnL -7795.202759), `codonml2.ctl`.

**`Mgene = 1` strides over encoded codon data.** `MultipleGenes` walks `com.z[]`
to each gene's slice with `nb = 3` for unclean codon data, but it runs after
`EncodeSeqs`, which has already collapsed codons to one byte per pattern
whether or not the data are clean and realloc'd `com.z[j]` to `com.npatt`.
`DistanceMatNG86` then reads past the buffer.
`examples/lysin/lysinYangSwanson2002.nuc` with `Mgene = 1` is clean after the
fix for `cleandata` 0 and 1; `Mgene` 0, 2, 3 and 4 are unaffected.

## Build

```
make codeml CUDA=1 GPU_ARCH=sm_86
```

`make` and `make all` are unchanged without `CUDA=1`, and build every program as before.

A CUDA-built binary on a host with no visible device falls back to the C path and returns identical output.

Two environment variables:

- `PAML_NO_CUDA=1` disables the device path at runtime, so one binary can be compared against itself with the compiler held constant.
- `PAML_SEED=n` overrides `SetSeed(-1, 0)`. codeml seeds from `/dev/urandom`, so two runs of one binary already differ in their iteration counts and in the last digits of the estimates; four runs on HIVNSsites gave 2.594607, 2.594606, 2.594606, 2.594607 for one parameter with `lfun` ranging over 1723-1862. Without a fixed seed no two builds are comparable.

Tested with CUDA 12.6 on sm_86 (gcc 13, glibc) and sm_89 (MSVC 2022).

`eigenQcodon` remains on the host and is now the largest single cost on small and medium trees: 3.63 s of the 7.41 s HIVNSsites run, 7.96 s of lysin, 1.52 s of MHC.
